### PR TITLE
Mobile and Desktop navigation Restructure/Split and README.md (updated)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "eslint.useFlatConfig": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.formatOnSave": false,
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.wordWrap": "on",
+  "editor.rulers": [100],
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true
+}

--- a/README.md
+++ b/README.md
@@ -1,46 +1,100 @@
-# Getting Started with Create React App
+# 🏈 I75 League - Fantasy Football Recaps
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+Welcome to the official repository for the **I75 League**, a private Fantasy Football league.
+This project transforms years of weekly email recaps into a clean, dynamic, modern web experience.
 
-## Available Scripts
+Built with **Next.js**, **TypeScript**, **TailwindCSS**, **Framer Motion**, **ESLint (Flat Config)**, **Husky**, and **Lint-Staged**.
 
-In the project directory, you can run:
+🧠 Full project wiki available here: [**I75 League Wiki**](https://github.com/Afroid/i75league/wiki/I75-League-Wiki)
 
-### `npm start`
+---
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## 🚀 Features
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
+- Dynamic Recap Pages (by year and week)
+- Animated, responsive layout
+- Clean desktop and mobile experience
+- ESLint + Husky pre-commit hooks for code quality
+- Future-proofed for admin features and CMS/image uploads
 
-### `npm test`
+---
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+## 📦 Local Development Setup
 
-### `npm run build`
+### Requirements
+- Node.js `v20.x`
+- NPM `v9.x` or higher
+- Git
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### Getting Started
+1. **Clone the repo:**
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
+```bash
+git clone https://github.com/Afroid/i75league.git
+cd i75league
+```
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+2. **Install dependencies:**
 
-### `npm run eject`
+```bash
+npm install
+```
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+3. **Start local dev server:**
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+```bash
+npm run dev
+```
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Open [http://localhost:3000](http://localhost:3000) to see the app.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+---
 
-## Learn More
+## 🛠 Code Quality Tools
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+- **ESLint** (Flat Config - modern setup)
+- **Husky** (Git pre-commit hooks)
+- **Lint-Staged** (only lints staged files on commit)
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+✅ Code will auto-lint on every commit.
+✅ Trailing spaces, formatting, and basic rules are enforced automatically.
+
+---
+
+## 📁 Project Structure (high-level)
+
+```
+/components       → UI components (Header, Navbar, Drawer, etc.)
+/data/recaps      → JSON recap content (by year)
+/lib              → Utility libraries (e.g., getRecaps.ts)
+/pages            → Routes (dynamic year/week routing)
+/public           → Static assets (images, icons)
+/styles           → TailwindCSS global styles
+/types            → TypeScript types (RecapData, RecapWeek, etc.)
+.vscode           → Project-wide VS Code settings (optional)
+.husky            → Git hooks
+```
+
+---
+
+## 🧐 Future Plans
+
+- Admin login per league
+- Multiple league support
+- Upload GIFs/screenshots to CDN
+- Dark mode
+- Mobile app (possible)
+
+---
+
+## ✍️ Author
+
+**John Brady**
+Built with 💚 for the I75 League.
+
+---
+
+## 📜 License
+
+This project is private to the I75 League.
+Contact the repo owner for questions.

--- a/components/DesktopNavbar.tsx
+++ b/components/DesktopNavbar.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { getRecaps } from "@/lib/getRecaps";
+
+const recapData = getRecaps();
+
+export default function DesktopNavbar() {
+  return (
+    <div className="flex items-center space-x-8">
+      {/* Static Nav Links */}
+      <Link href="/" className="hover:text-green-400 transition-colors duration-300">
+        Home
+      </Link>
+      <Link href="/about" className="hover:text-green-400 transition-colors duration-300">
+        About
+      </Link>
+      <Link href="/contact" className="hover:text-green-400 transition-colors duration-300">
+        Contact
+      </Link>
+
+      {/* Recaps Flyout (like ESPN's dropdowns) */}
+      <div className="relative group">
+        <button className="hover:text-green-400 transition-colors duration-300">
+          Recaps
+        </button>
+        <div className="absolute left-0 top-full hidden group-hover:flex flex-col mt-2 bg-white text-black shadow-lg rounded-md p-2 z-50 min-w-[150px]">
+          {Object.keys(recapData)
+            .sort((a, b) => Number(b) - Number(a))
+            .map((year) => (
+              <Link
+                key={year}
+                href={`/recaps/${year}`}
+                className="px-4 py-2 hover:bg-green-100 rounded-md transition-colors duration-300"
+              >
+                {year} Season
+              </Link>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,36 +1,49 @@
 import { useState } from "react";
-import Link from "next/link";
-import ResponsiveDrawer from "./ResponsiveDrawer";
+import Logo from "./Logo";
+import DesktopNavbar from "./DesktopNavbar";
+import MobileDrawer from "./MobileDrawer";
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const toggleDrawer = () => setIsOpen(!isOpen);
+  const toggleDrawer = () => setIsOpen((prev) => !prev);
+  const closeDrawer = () => setIsOpen(false);
 
   return (
     <>
-      <header className="fixed top-0 left-0 w-full z-50 bg-white shadow h-16 flex items-center justify-between px-4 lg:pl-[250px]">
-        {/* Mobile hamburger */}
-        <button
-          onClick={toggleDrawer}
-          className="lg:hidden bg-transparent border-none"
-          aria-label="Open menu"
-        >
-          <div className="w-6 h-4 flex flex-col justify-between cursor-pointer">
-            <span className="h-[3px] bg-gray-800 rounded" />
-            <span className="h-[3px] bg-gray-800 rounded" />
-            <span className="h-[3px] bg-gray-800 rounded" />
+      {/* Main Header */}
+      <header className="fixed top-0 left-0 w-full z-50 bg-black text-white shadow-md h-16">
+        <div className="max-w-7xl mx-auto px-4 flex items-center justify-between h-full">
+          {/* Mobile Hamburger */}
+          <div className="lg:hidden">
+            <button
+              onClick={toggleDrawer}
+              className="focus:outline-none"
+              aria-label="Open menu"
+            >
+              {/* Hamburger Icon */}
+              <div className="space-y-1">
+                <div className="w-6 h-0.5 bg-white" />
+                <div className="w-6 h-0.5 bg-white" />
+                <div className="w-6 h-0.5 bg-white" />
+              </div>
+            </button>
           </div>
-        </button>
 
-        {/* Site title as Home link */}
-        <Link href="/" className="text-xl font-bold pl-2 hover:text-blue-600 transition-colors duration-200">
-          I75 League
-        </Link>
+          {/* Logo (always visible) */}
+          <div className="flex-1 flex justify-center lg:justify-start">
+            <Logo />
+          </div>
+
+          {/* Desktop Navbar (hidden on mobile) */}
+          <nav className="hidden lg:flex items-center space-x-8">
+            <DesktopNavbar />
+          </nav>
+        </div>
       </header>
 
-      {/* Drawer outside header so it doesn’t get clipped */}
-      <ResponsiveDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      {/* Mobile Drawer (slides out) */}
+      <MobileDrawer isOpen={isOpen} onClose={closeDrawer} />
     </>
   );
 }

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export default function Logo() {
+  return (
+    <Link href="/" className="relative inline-flex items-center justify-center group">
+      {/* Background Layers */}
+
+      {/* Darker background, slightly wider */}
+      <span
+        className="
+          absolute top-0 bottom-0 left-[-10px] right-[-20px] bg-green-600
+          skew-x-[-25deg] -z-20
+          transition-transform duration-500 ease-in-out
+          group-hover:scale-110 group-hover:bg-green-700
+        "
+      />
+
+      {/* Lighter background, slightly maller */}
+      <span
+        className="
+          absolute top-0 bottom-0 left-0 right-[-10px] bg-green-500
+          skew-x-[-25deg] -z-10
+          transition-transform duration-500 ease-in-out
+          group-hover:scale-105 group-hover:shadow-lg
+        "
+      />
+
+      {/* Text (no scaling) */}
+      <span className="
+        relative flex items-center justify-center
+        text-2xl font-extrabold text-white
+        tracking-wide px-4 py-1
+      ">
+        I75 League
+      </span>
+    </Link>
+  );
+}

--- a/components/MobileDrawer.tsx
+++ b/components/MobileDrawer.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
+import { getRecaps } from "@/lib/getRecaps";
+
+const recapData = getRecaps();
+
+export default function MobileDrawer({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 bg-black/50 z-[1000]"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="fixed top-0 left-0 w-64 bg-white h-full p-6 z-[1001] flex flex-col gap-6"
+            initial={{ x: "-100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "-100%" }}
+            transition={{ type: "tween", duration: 0.4 }}
+          >
+            {/* Close Button */}
+            <button
+              onClick={onClose}
+              className="self-end text-black hover:text-red-500 transition"
+              aria-label="Close menu"
+            >
+              ✕
+            </button>
+
+            {/* Static Nav Links */}
+            <div className="flex flex-col gap-4">
+              <Link href="/" onClick={onClose} className="text-lg hover:text-green-600">
+                Home
+              </Link>
+              <Link href="/about" onClick={onClose} className="text-lg hover:text-green-600">
+                About
+              </Link>
+              <Link href="/contact" onClick={onClose} className="text-lg hover:text-green-600">
+                Contact
+              </Link>
+            </div>
+
+            {/* Recaps Section */}
+            <div>
+              <h2 className="font-bold text-gray-700 mb-2">Recaps</h2>
+              {Object.entries(recapData)
+                .sort((a, b) => Number(b[0]) - Number(a[0]))
+                .map(([year, weeks]) => (
+                  <div key={year}>
+                    <div className="font-semibold text-gray-900">{year}</div>
+                    <div className="ml-4 flex flex-col gap-1 mt-1">
+                      {weeks.map((week) => (
+                        <Link
+                          key={week}
+                          href={`/recaps/${year}/week-${week}`}
+                          onClick={onClose}
+                          className="text-sm text-gray-700 hover:text-green-600"
+                        >
+                          Week {week}
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+            </div>
+
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/data/recaps/2023.json
+++ b/data/recaps/2023.json
@@ -60,8 +60,37 @@
             "content": "As always, good luck to you all, except for Smelly.\n(I hope you stub your toe.)"
           }
         ]
+      },
+      {
+        "week": 7,
+        "title": "Week 7 Recap",
+        "sections": [
+          {
+            "type": "intro",
+            "content": "Good day to you all, except Heg.\n\nYou know, it's pretty nice when I go undefeated..."
+          },
+          {
+            "type": "tidbits",
+            "content": "There are six teams at 2-1. Ryan leads in Points For..."
+          },
+          {
+            "type": "injuries",
+            "content": "CMAC - I'm Bromberg chunky\nCooper Kupp - Let The Force Be With Vu\n..."
+          },
+          {
+            "type": "gameNotes",
+            "content": "Week 1 - (162.44) Rev. Dongo Pewee\nHonorable Mention..."
+          },
+          {
+            "type": "matchups",
+            "content": "Let The Force Be With Vu vs A Hall Lotta Love\n136.04–137.05\n..."
+          },
+          {
+            "type": "farewell",
+            "content": "As always, good luck to you all, except for Smelly.\n(I hope you stub your toe.)"
+          }
+        ]
       }
     ]
   }
-  
-  
+

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,7 @@ export default function Home() {
         <meta name="description" content="Where everybody knows your name." />
       </Head>
 
-      <main className="pt-4 lg:pl-[240px]">
+      <main className="pt-4">
         <h1 className="text-4xl text-green-600 font-bold mb-4">Welcome to I75 League</h1>
         <h1 className="text-3xl text-orange-600 font-bold mb-4">Links are working with dummy data.</h1>
         <p className="text-lg text-gray-700 mb-4">

--- a/pages/recaps/[year]/index.tsx
+++ b/pages/recaps/[year]/index.tsx
@@ -3,6 +3,7 @@ import path from "path";
 import Link from "next/link";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { RecapData } from "@/types/types";
+import { motion } from "framer-motion";
 
 interface Props {
   year: number;
@@ -12,19 +13,46 @@ interface Props {
 export default function YearPage({ year, weeks }: Props) {
   return (
     <div className="pt-4 px-4 max-w-2xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">Recaps for {year}</h1>
-      <ul className="space-y-2">
-        {weeks.map((week) => (
-          <li key={week}>
+
+      <div className="text-center">
+        <div className="inline-block">
+          <h1 className="text-4xl lg:text-5xl font-extrabold text-gray-900 mb-2">
+            {year} Season Recaps
+          </h1>
+          <div className="h-1 w-full bg-gradient-to-r from-green-500 to-green-700 rounded-full mb-6"></div>
+        </div>
+      </div>
+
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        {weeks.map((week, idx) => (
+          <motion.li
+            key={week}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: idx * 0.1 }}
+          >
             <Link
               href={`/recaps/${year}/week-${week}`}
-              className="text-blue-600 hover:underline text-lg"
+              className="
+                block rounded-lg shadow-md
+                bg-white hover:bg-green-50
+                p-6 text-center transition
+                border border-gray-200 hover:border-green-400
+                transform transition-transform
+                hover:shadow-lg hover:scale-105 hover:-translate-y-1
+                flex flex-col justify-center
+                min-h-[150px]
+              "
             >
-              Week {week} Recap
+              <h2 className="text-xl font-semibold text-gray-900 mb-2">
+                Week {week}
+              </h2>
+              <p className="text-gray-600">View Recap</p>
             </Link>
-          </li>
+          </motion.li>
         ))}
       </ul>
+
     </div>
   );
 }


### PR DESCRIPTION
Mobile and Desktop navigation have been separated. 
Header has been changed to take in Mobile, Logo, and Desktop. 
Removed unnecessary padding from the index file because the fixed drawer won't be there for desktop now.
README.md has been updated and it references the new Wiki page.


**Upcoming changes**
More styling changes and layout changes are coming to the desktop next.
The original ResponsiveDrawer.tsx will be deleted soon.