### PR TITLE
View All Recaps Page

### DIFF
--- a/components/DesktopNavbar.tsx
+++ b/components/DesktopNavbar.tsx
@@ -211,7 +211,7 @@ export default function DesktopNavbar() {
 
             {/* View All Recaps */}
             <Link
-              href="/recaps"
+              href="/recaps/viewAllRecaps"
               className="
                 block text-center
                 px-4 py-2

--- a/components/DesktopNavbar.tsx
+++ b/components/DesktopNavbar.tsx
@@ -218,6 +218,7 @@ export default function DesktopNavbar() {
                 text-blue-600 hover:text-blue-800 font-semibold hover:bg-blue-300
                 rounded-md transition-colors duration-300
               "
+              onClick={() => setIsFlyoutOpen(false)}
             >
               View All Recaps
             </Link>

--- a/components/MobileDrawer.tsx
+++ b/components/MobileDrawer.tsx
@@ -120,7 +120,7 @@ export default function MobileDrawer({ isOpen, onClose }: MobileDrawerProps) {
 
               <div className="mb-2">
                 <Link
-                  href="/recaps"
+                  href="/recaps/viewAllRecaps"
                   onClick={onClose}
                   className="text-md text-blue-600"
                 >

--- a/data/recaps/2021.json
+++ b/data/recaps/2021.json
@@ -2,6 +2,36 @@
     "year": 2021,
     "recaps": [
       {
+        "week": 1,
+        "title": "Week 1 Recap",
+        "sections": [
+          {
+            "type": "intro",
+            "content": "Good day to you all, except Heg.\n\nYou know, it's pretty nice when I go undefeated..."
+          },
+          {
+            "type": "tidbits",
+            "content": "There are six teams at 2-1. Ryan leads in Points For..."
+          },
+          {
+            "type": "injuries",
+            "content": "CMAC - I'm Bromberg chunky\nCooper Kupp - Let The Force Be With Vu\n..."
+          },
+          {
+            "type": "gameNotes",
+            "content": "Week 1 - (162.44) Rev. Dongo Pewee\nHonorable Mention..."
+          },
+          {
+            "type": "matchups",
+            "content": "Let The Force Be With Vu vs A Hall Lotta Love\n136.04–137.05\n..."
+          },
+          {
+            "type": "farewell",
+            "content": "As always, good luck to you all, except for Smelly.\n(I hope you stub your toe.)"
+          }
+        ]
+      },
+      {
         "week": 2,
         "title": "Week 2 Recap",
         "sections": [
@@ -64,6 +94,36 @@
       {
         "week": 7,
         "title": "Week 7 Recap",
+        "sections": [
+          {
+            "type": "intro",
+            "content": "Good day to you all, except Heg.\n\nYou know, it's pretty nice when I go undefeated..."
+          },
+          {
+            "type": "tidbits",
+            "content": "There are six teams at 2-1. Ryan leads in Points For..."
+          },
+          {
+            "type": "injuries",
+            "content": "CMAC - I'm Bromberg chunky\nCooper Kupp - Let The Force Be With Vu\n..."
+          },
+          {
+            "type": "gameNotes",
+            "content": "Week 1 - (162.44) Rev. Dongo Pewee\nHonorable Mention..."
+          },
+          {
+            "type": "matchups",
+            "content": "Let The Force Be With Vu vs A Hall Lotta Love\n136.04–137.05\n..."
+          },
+          {
+            "type": "farewell",
+            "content": "As always, good luck to you all, except for Smelly.\n(I hope you stub your toe.)"
+          }
+        ]
+      },
+      {
+        "week": 12,
+        "title": "Week 12 Recap",
         "sections": [
           {
             "type": "intro",

--- a/data/recaps/2022.json
+++ b/data/recaps/2022.json
@@ -2,8 +2,8 @@
     "year": 2022,
     "recaps": [
       {
-        "week": 5,
-        "title": "Week 5 Recap",
+        "week": 4,
+        "title": "Week 4 Recap",
         "sections": [
           {
             "type": "intro",
@@ -32,8 +32,8 @@
         ]
       },
       {
-        "week": 4,
-        "title": "Week 4 Recap",
+        "week": 5,
+        "title": "Week 5 Recap",
         "sections": [
           {
             "type": "intro",

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -77,8 +77,8 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
     .filter((entry) => {
       const combinedText = `${entry.year} season week ${entry.week}`.toLowerCase();
       const matchesSearch = searchTerm.trim()
-        ? combinedText.includes(searchTerm.trim().toLowerCase())
-        : true;
+      ? new RegExp(`\\b${searchTerm.trim().toLowerCase()}\\b`).test(combinedText)
+      : true;
       const matchesYear = yearFilter ? entry.year === yearFilter : true;
       return matchesSearch && matchesYear;
     })

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -55,6 +55,24 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
     router.replace({ pathname: router.pathname, query: newQuery }, undefined, { shallow: true });
   };
 
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+    updateQuery({ search: value });
+
+    if (/^\d{4}$/.test(value)) {
+      setYearFilter("");
+      updateQuery({ search: value, year: "" });
+    }
+  };
+
+  const handleYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedYear = e.target.value;
+    setYearFilter(selectedYear);
+    setSearchTerm("");
+    updateQuery({ year: selectedYear, search: "" });
+  };
+
   const filteredRecaps = allRecaps
     .filter((entry) => {
       const combinedText = `${entry.year} season week ${entry.week}`.toLowerCase();
@@ -88,10 +106,7 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
           type="text"
           placeholder="Search by year or week..."
           value={searchTerm}
-          onChange={(e) => {
-            setSearchTerm(e.target.value);
-            updateQuery({ search: e.target.value });
-          }}
+          onChange={handleSearchChange}
           className="border px-3 py-2 rounded-md w-full sm:max-w-xs"
         />
 
@@ -99,10 +114,7 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
           <div className="flex justify-between w-full sm:w-auto sm:gap-4">
             <select
               value={yearFilter}
-              onChange={(e) => {
-                setYearFilter(e.target.value);
-                updateQuery({ year: e.target.value });
-              }}
+              onChange={handleYearChange}
               className="border px-3 py-2 rounded-md w-[48%] sm:w-auto"
             >
               <option value="">All Years</option>

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -54,7 +54,7 @@ function Dropdown({ label, options, value, onChange }: {
   }, []);
 
   return (
-    <div ref={dropdownRef} className="relative w-full sm:w-auto">
+    <div ref={dropdownRef} className="relative w-full">
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex justify-between items-center border px-3 py-2 rounded-md w-full"
@@ -170,7 +170,7 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
 
         <div className="flex flex-col sm:flex-row w-full sm:w-auto sm:gap-4 gap-2">
           <div className="flex flex-row gap-2 w-full sm:w-auto">
-            <div className="w-1/2 sm:w-auto">
+            <div className="w-2/5 sm:w-auto lg:w-28">
               <Dropdown
                 label="All Years"
                 options={[
@@ -186,7 +186,7 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
               />
             </div>
 
-            <div className="w-1/2 sm:w-auto">
+            <div className="w-3/5 sm:w-auto lg:w-40">
               <Dropdown
                 label="Sort Order"
                 options={[

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { RecapData } from "@/types/types";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, Search } from "lucide-react";
 
 interface RecapEntry {
   year: string;
@@ -142,13 +142,18 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
   return (
     <div className="pt-4 max-w-4xl mx-auto px-4">
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <input
-          type="text"
-          placeholder="Search by year or week..."
-          value={searchTerm}
-          onChange={handleSearchChange}
-          className="border px-3 py-2 rounded-md w-full sm:max-w-xs"
-        />
+        <div className="relative w-full sm:max-w-xs">
+          <input
+            type="text"
+            placeholder="Search by year or week..."
+            value={searchTerm}
+            onChange={handleSearchChange}
+            className="border px-3 py-2 rounded-md w-full sm:max-w-xs"
+          />
+          <Search
+            className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={18}
+          />
+        </div>
 
         <div className="flex flex-col w-full gap-2 sm:flex-row sm:w-auto sm:gap-4 sm:items-center">
           <Dropdown

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { RecapData } from "@/types/types";
 import { ChevronDown, ChevronUp, Search } from "lucide-react";
@@ -39,9 +39,22 @@ function Dropdown({ label, options, value, onChange }: {
   onChange: (val: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
 
   return (
-    <div className="relative w-full sm:w-auto">
+    <div ref={dropdownRef} className="relative w-full sm:w-auto">
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex justify-between items-center border px-3 py-2 rounded-md w-full"

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -1,0 +1,162 @@
+import fs from "fs";
+import path from "path";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { RecapData } from "@/types/types";
+
+interface RecapEntry {
+  year: string;
+  week: number;
+}
+
+export async function getStaticProps() {
+  const dir = path.join(process.cwd(), "data", "recaps");
+  const files = fs.readdirSync(dir);
+  const allRecaps: RecapEntry[] = [];
+
+  for (const file of files) {
+    const year = file.replace(".json", "");
+    const data = JSON.parse(fs.readFileSync(path.join(dir, file), "utf-8")) as RecapData;
+    for (const recap of data.recaps) {
+      allRecaps.push({ year, week: recap.week });
+    }
+  }
+
+  return {
+    props: {
+      allRecaps,
+    },
+  };
+}
+
+export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry[] }) {
+  const router = useRouter();
+  const [sortOrder, setSortOrder] = useState("desc");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [yearFilter, setYearFilter] = useState("");
+
+  useEffect(() => {
+    const { sort, search, year } = router.query;
+    if (typeof sort === "string") setSortOrder(sort);
+    if (typeof search === "string") setSearchTerm(search);
+    if (typeof year === "string") setYearFilter(year);
+  }, [router.query]);
+
+  const updateQuery = (updates: Record<string, string>) => {
+    const newQuery = {
+      ...router.query,
+      ...updates,
+    };
+    Object.keys(newQuery).forEach((key) => {
+      if (!newQuery[key]) delete newQuery[key];
+    });
+    router.replace({ pathname: router.pathname, query: newQuery }, undefined, { shallow: true });
+  };
+
+  const filteredRecaps = allRecaps
+    .filter((entry) => {
+      const combinedText = `${entry.year} season week ${entry.week}`.toLowerCase();
+      const matchesSearch = searchTerm.trim()
+        ? combinedText.includes(searchTerm.trim().toLowerCase())
+        : true;
+      const matchesYear = yearFilter ? entry.year === yearFilter : true;
+      return matchesSearch && matchesYear;
+    })
+    .sort((a, b) => {
+      const aYear = Number(a.year);
+      const bYear = Number(b.year);
+      const aWeek = a.week;
+      const bWeek = b.week;
+
+      if (aYear !== bYear) {
+        return sortOrder === "desc" ? bYear - aYear : aYear - bYear;
+      }
+
+      return sortOrder === "desc" ? bWeek - aWeek : aWeek - bWeek;
+    });
+
+  const uniqueYears = Array.from(new Set(allRecaps.map((r) => r.year))).sort(
+    (a, b) => Number(b) - Number(a)
+  );
+
+  return (
+    <div className="pt-4 max-w-4xl mx-auto px-4">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <input
+          type="text"
+          placeholder="Search by year or week..."
+          value={searchTerm}
+          onChange={(e) => {
+            setSearchTerm(e.target.value);
+            updateQuery({ search: e.target.value });
+          }}
+          className="border px-3 py-2 rounded-md w-full sm:max-w-xs"
+        />
+
+        <div className="flex flex-col w-full gap-2 sm:flex-row sm:w-auto sm:gap-4 sm:items-center">
+          <div className="flex justify-between w-full sm:w-auto sm:gap-4">
+            <select
+              value={yearFilter}
+              onChange={(e) => {
+                setYearFilter(e.target.value);
+                updateQuery({ year: e.target.value });
+              }}
+              className="border px-3 py-2 rounded-md w-[48%] sm:w-auto"
+            >
+              <option value="">All Years</option>
+              {uniqueYears.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+
+            <select
+              value={sortOrder}
+              onChange={(e) => {
+                setSortOrder(e.target.value);
+                updateQuery({ sort: e.target.value });
+              }}
+              className="border px-3 py-2 rounded-md w-[48%] sm:w-auto"
+            >
+              <option value="desc">Latest to Oldest</option>
+              <option value="asc">Oldest to Latest</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <ul className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        {filteredRecaps.map((entry, idx) => (
+          <motion.li
+            key={`${entry.year}-${entry.week}`}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: idx * 0.03 }}
+          >
+            <Link
+              href={`/recaps/${entry.year}/week-${entry.week}`}
+              className="
+                block rounded-lg shadow-md
+                bg-white hover:bg-green-50
+                p-6 text-center transition
+                border border-gray-200 hover:border-green-400
+                transform transition-transform
+                hover:shadow-lg hover:scale-105 hover:-translate-y-1
+                flex flex-col justify-center
+                min-h-[150px]
+              "
+            >
+              <h2 className="text-xl font-semibold text-gray-900 mb-2">
+                Week {entry.week}
+              </h2>
+              <p className="text-gray-600">Season {entry.year}</p>
+            </Link>
+          </motion.li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/pages/recaps/viewAllRecaps.tsx
+++ b/pages/recaps/viewAllRecaps.tsx
@@ -168,33 +168,39 @@ export default function ViewAllRecapsPage({ allRecaps }: { allRecaps: RecapEntry
           />
         </div>
 
-        <div className="flex flex-col w-full gap-2 sm:flex-row sm:w-auto sm:gap-4 sm:items-center">
-          <Dropdown
-            label="All Years"
-            options={[
-              { label: "All Years", value: "" },
-              ...uniqueYears.map((year) => ({ label: year, value: year }))
-            ]}
-            value={yearFilter}
-            onChange={(val) => {
-              setYearFilter(val);
-              setSearchTerm("");
-              updateQuery({ year: val, search: "" });
-            }}
-          />
+        <div className="flex flex-col sm:flex-row w-full sm:w-auto sm:gap-4 gap-2">
+          <div className="flex flex-row gap-2 w-full sm:w-auto">
+            <div className="w-1/2 sm:w-auto">
+              <Dropdown
+                label="All Years"
+                options={[
+                  { label: "All Years", value: "" },
+                  ...uniqueYears.map((year) => ({ label: year, value: year }))
+                ]}
+                value={yearFilter}
+                onChange={(val) => {
+                  setYearFilter(val);
+                  setSearchTerm("");
+                  updateQuery({ year: val, search: "" });
+                }}
+              />
+            </div>
 
-          <Dropdown
-            label="Sort Order"
-            options={[
-              { label: "Latest to Oldest", value: "desc" },
-              { label: "Oldest to Latest", value: "asc" },
-            ]}
-            value={sortOrder}
-            onChange={(val) => {
-              setSortOrder(val);
-              updateQuery({ sort: val });
-            }}
-          />
+            <div className="w-1/2 sm:w-auto">
+              <Dropdown
+                label="Sort Order"
+                options={[
+                  { label: "Latest to Oldest", value: "desc" },
+                  { label: "Oldest to Latest", value: "asc" },
+                ]}
+                value={sortOrder}
+                onChange={(val) => {
+                  setSortOrder(val);
+                  updateQuery({ sort: val });
+                }}
+              />
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## 📝 Summary

Brief overview of the change and its purpose.

_Example: Added mobile drawer accordion functionality for weekly recaps._

This implements the View All Recaps page.

---

## 🔗 Story Reference (if applicable)

Add a link to a ticket or planning doc if one exists.

_Example: [JIRA-42](https://your-jira-instance.atlassian.net/browse/JIRA-42)_

---

## 🔧 Changes

- ✅ Major updates or additions
- 🐛 Bug fixes or refactors
- 🎨 Styling/UX updates

- Search bar (by year or week), Filter (by year), Sort (by ascending/descending)
- PLP style
- Edge cases have been addressed
- Custom dropdowns
- Parameters are preserved in the URL
- Highlights selections in dropdowns and color changes on hover for desktop

---

## 📸 Screenshots / Demos

> Required for UI-related changes
**Mobile**
![image](https://github.com/user-attachments/assets/bbb8cdfc-4832-45ae-b88c-7b5671cd7597)
![image](https://github.com/user-attachments/assets/c56bdf71-5f50-4995-90eb-838eb2c65e03)

**Desktop**
![image](https://github.com/user-attachments/assets/6453e92c-a0f0-43d7-9e29-1e29a85da79a)
![image](https://github.com/user-attachments/assets/b625f557-3500-470b-8a0f-4c9a07c4f670)

---

## 🧪 Test Results

### Unit Tests - Jest: Add Screenshot of tests passing

_EX:_
PASS  components/Header.test.tsx
✓ renders correctly (42ms)
✓ toggles mobile menu (35ms)

Test Suites: 3 passed, 3 total
Tests:       8 passed, 8 total

Not applicable, yet.

---

## ✅ Checklist

- [x] Story or issue reference included (if applicable)
- [x] Code compiles and lints with no errors
- [x] Mobile and desktop behavior verified
- [x] All unit tests passing (if applicable)
- [x] E2E tests run and verified (if applicable)
- [x] All components tested visually
- [x] Screenshots/demos attached if UI changed
- [x] No major performance regressions

## 🧪 Notes

_Add any caveats, follow-ups, or test notes here. If this is a WIP, explain what's left._
